### PR TITLE
Workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ to the README as new text lines.
 --- insert here ---
 
 more text
-test contents
-and with polling?
-and with experimental?
+using the new feature...
 
 --- until here ----

--- a/repro
+++ b/repro
@@ -3,12 +3,12 @@
 set -e
 set -x
 
+git fetch --all
 # switch to the integrated deployment branch
 git checkout deploy
 # sync the integrated deployment branch with the repo
 # *** skipping this step fixes the problem ***
 # git pull is a shorthand for:
-git fetch --all
 git merge FETCH_HEAD
 # *** after this point the files in atom will not be reloaded ***
 

--- a/repro
+++ b/repro
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-# fetch the integrated deployment branch, it's head is saved as FETCH_HEAD
+# fetch the integrated deployment branch, its head is saved as FETCH_HEAD
 git fetch origin deploy
 # switch to the integrated deployment branch
 git checkout deploy

--- a/repro
+++ b/repro
@@ -3,14 +3,12 @@
 set -e
 set -x
 
+# fetch the integrated deployment branch, it's head is saved as FETCH_HEAD
 git fetch origin deploy
 # switch to the integrated deployment branch
 git checkout deploy
-# sync the integrated deployment branch with the repo
-# *** skipping this step fixes the problem ***
-# git pull is a shorthand for:
+# merge the previously fetched contents of the integrated deployment branch
 git merge FETCH_HEAD
-# *** after this point the files in atom will not be reloaded ***
 
 # merge the feature branch
 git merge --no-ff feature -m "merge the feature"

--- a/repro
+++ b/repro
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-git fetch --all
+git fetch origin deploy
 # switch to the integrated deployment branch
 git checkout deploy
 # sync the integrated deployment branch with the repo

--- a/repro
+++ b/repro
@@ -7,7 +7,9 @@ set -x
 git checkout deploy
 # sync the integrated deployment branch with the repo
 # *** skipping this step fixes the problem ***
-git pull
+# git pull is a shorthand for:
+git fetch
+git merge FETCH_HEAD
 # *** after this point the files in atom will not be reloaded ***
 
 # merge the feature branch

--- a/repro
+++ b/repro
@@ -8,7 +8,7 @@ git checkout deploy
 # sync the integrated deployment branch with the repo
 # *** skipping this step fixes the problem ***
 # git pull is a shorthand for:
-git fetch
+git fetch --all
 git merge FETCH_HEAD
 # *** after this point the files in atom will not be reloaded ***
 


### PR DESCRIPTION
This branch demonstrates a workaround for the `git pull` vs `atom` problem. 

Rationale: 

According to the [git pull reference][1]:

> In its default mode, `git pull` is shorthand for `git fetch` followed by `git merge FETCH_HEAD`.

It appears that if we split the two steps and insert a different git operation from the original deploy script between them the problem doesn't manifest. The resulting script still performs the intended pull/merge properly.

[1]: https://git-scm.com/docs/git-pull

